### PR TITLE
Add @deprecated tags to deprecated JsonGenerationException constructors

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/JsonGenerationException.java
+++ b/src/main/java/com/fasterxml/jackson/core/JsonGenerationException.java
@@ -17,17 +17,26 @@ public class JsonGenerationException
 {
     private final static long serialVersionUID = 123; // eclipse complains otherwise
 
-    @Deprecated // since 2.7
+    /**
+     * @deprecated since 2.7
+     */
+    @Deprecated
     public JsonGenerationException(Throwable rootCause) {
         super(rootCause, null);
     }
 
-    @Deprecated // since 2.7
+    /**
+     * @deprecated since 2.7
+     */
+    @Deprecated
     public JsonGenerationException(String msg) {
         super(msg, null);
     }
 
-    @Deprecated // since 2.7
+    /**
+     * @deprecated since 2.7
+     */
+    @Deprecated
     public JsonGenerationException(String msg, Throwable rootCause) {
         super(msg, rootCause, null);
     }


### PR DESCRIPTION
**Summary**

Add deprecated tags to JsonGenerationException constructors as flagged by SonarQube (rule java:S1123).

Closes #7 