### PR TITLE
fix(json-parser): add missing break to prevent switch-case fall-through for '.' token

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
+++ b/src/main/java/com/fasterxml/jackson/core/json/UTF8DataInputJsonParser.java
@@ -807,7 +807,9 @@ public class UTF8DataInputJsonParser
             break;
         case '.': // as per [core#611]
             t = _parseFloatThatStartsWithPeriod(false, false);
-        case '0':
+            // Fix: previously missing break caused switch fall-through, overwriting the parsed '.' value.
+            break;
+            case '0':
         case '1':
         case '2':
         case '3':


### PR DESCRIPTION
SpotBugs identified a correctness issue in UTF8DataInputJsonParser where the 
'.' case was missing a break statement, causing unintended fall-through into 
digit-handling cases and overwriting the parsed value. This update adds the 
missing break to ensure correct parsing.

Fixes #11
