### PR TITLE
SpotBugs: prevent exposure of static ContentReference in redacted()

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
+++ b/src/main/java/com/fasterxml/jackson/core/io/ContentReference.java
@@ -155,13 +155,15 @@ public class ContentReference
      * is not to be exposed: different from {@link #unknown()} where
      * content is not available to be referenced.
      *
-     * @return Placeholder instance to use in cases where reference is explicitly
-     *   blocked, usually for security reasons.
+     * Returns a new instance instead of the shared static REDACTED_CONTENT
+     * to avoid exposing internal static mutable state
+     * (SpotBugs: public static method may expose internal representation).
      *
      * @since 2.16
      */
     public static ContentReference redacted() {
-        return REDACTED_CONTENT;
+        // Defensive copy: create a new instance with the same logical values
+        return new ContentReference(false, null, ErrorReportConfiguration.defaults());
     }
 
 


### PR DESCRIPTION
This PR fixes a SpotBugs EI_EXPOSE_STATIC_REP vulnerability reported in ContentReference.redacted().

The method previously returned a direct reference to the static mutable instance REDACTED_CONTENT, allowing callers to modify shared internal state.

The fix introduces a defensive copy, ensuring callers receive a new ContentReference instance with the same values, preventing mutation of the internal static reference.

SpotBugs re-scan confirms that the issue is resolved.

Fixes #20.